### PR TITLE
feat: Add generic receptor-only monitoring

### DIFF
--- a/examples/example_receptor_monitor.jl
+++ b/examples/example_receptor_monitor.jl
@@ -1,0 +1,124 @@
+# examples/example_receptor_monitor.jl
+
+using HydrodynamicTransport
+
+# ---------------------------------------------------------
+# Example: Using Generic Receptor Monitoring in a Simulation
+# ---------------------------------------------------------
+#
+# This script demonstrates how to set up receptor monitoring
+# to write high-frequency time series data at specific points
+# while skipping full-grid model state output.
+# ---------------------------------------------------------
+
+# Placeholders for paths and settings
+const OUTPUT_DIR = "path/to/output"
+const HYDRO_FILE = "path/to/hydro_input.nc"
+
+# Example simulation settings
+simulation_start_time_seconds = 0.0
+simulation_end_time_seconds   = 24.0 * 3600.0  # 1 day
+dt_initial_seconds            = 60.0
+
+# ---------------------------------------------------------
+# 1. Setup Grid, State, Sources (Mocks for the example)
+# ---------------------------------------------------------
+# In a real run, you would load or initialize your real grid.
+println("Initializing mock grid and state...")
+grid = initialize_cartesian_grid(100, 100, 10, 1000.0, 10.0, 5.0)
+
+tracers = (:TRACER_A, :TRACER_B)
+state = initialize_state(grid, tracers)
+
+sources = PointSource[]
+
+# ---------------------------------------------------------
+# 2. Setup Receptor Monitors
+# ---------------------------------------------------------
+# We want to normalize the raw extracted value for each tracer
+# by the total mass or some standard normalization constant.
+normalization_by_tracer = Dict(
+    :TRACER_A => 1.0e12,
+    :TRACER_B => 1.0e12,
+)
+
+# Example: Receptor A at lon/lat
+# Using `create_receptor_monitor_from_lonlat` handles finding
+# the correct grid indices `i` and `j` internally.
+receptor_a_lon = -1.5
+receptor_a_lat = 47.0
+
+# NOTE: If using a simple Cartesian mock grid without real lon/lat coords,
+# this function call will fail unless grid.lon_rho and grid.lat_rho exist.
+# For the sake of the generic example structure, we show the API as it would
+# look with a real geographic grid (e.g., CurvilinearGrid).
+#
+# monitor_a = HydrodynamicTransport.create_receptor_monitor_from_lonlat(
+#     grid;
+#     receptor_id = "RECEPTOR_A",
+#     lon = receptor_a_lon,
+#     lat = receptor_a_lat,
+#     tracer_names = [:TRACER_A, :TRACER_B],
+#     normalization_by_tracer = normalization_by_tracer,
+#     output_file = joinpath(OUTPUT_DIR, "RECEPTOR_A_monitor_1h.csv"),
+#     start_time_seconds = simulation_start_time_seconds,
+# )
+
+# For this purely abstract Cartesian grid example, we construct the ReceptorMonitor directly:
+monitor_a = ReceptorMonitor(
+    receptor_id = "RECEPTOR_A",
+    i = 50,
+    j = 50,
+    i_array = 50 + grid.ng,  # account for halo
+    j_array = 50 + grid.ng,
+    tracer_names = [:TRACER_A, :TRACER_B],
+    normalization_by_tracer = normalization_by_tracer,
+    output_file = joinpath(OUTPUT_DIR, "RECEPTOR_A_monitor_1h.csv"),
+    start_time_seconds = simulation_start_time_seconds
+)
+
+monitor_b = ReceptorMonitor(
+    receptor_id = "RECEPTOR_B",
+    i = 75,
+    j = 25,
+    i_array = 75 + grid.ng,
+    j_array = 25 + grid.ng,
+    tracer_names = [:TRACER_A, :TRACER_B],
+    normalization_by_tracer = normalization_by_tracer,
+    output_file = joinpath(OUTPUT_DIR, "RECEPTOR_B_monitor_1h.csv"),
+    start_time_seconds = simulation_start_time_seconds
+)
+
+# ---------------------------------------------------------
+# 3. Run Simulation with Monitoring
+# ---------------------------------------------------------
+println("Starting simulation...")
+
+# Here we disable full_state output (write_full_state = false),
+# and enable receptor output every 1 hour.
+HydrodynamicTransport.run_simulation(
+    grid,
+    state,
+    sources,
+    simulation_start_time_seconds,
+    simulation_end_time_seconds,
+    dt_initial_seconds;
+
+    # Standard output dir handling
+    output_dir = OUTPUT_DIR,
+
+    # ---------------------------------------------------
+    # NEW RECEPTOR MONITOR ARGS
+    # ---------------------------------------------------
+    write_full_state = false,
+    full_state_output_interval = 24.0 * 3600.0,
+
+    receptor_monitors = [monitor_a, monitor_b],
+    receptor_monitor_interval = 1.0 * 3600.0,
+    # ---------------------------------------------------
+
+    use_adaptive_dt = true,
+    # (other numerical parameters remain unchanged)
+)
+
+println("Simulation complete. Receptor CSV files should be written in $OUTPUT_DIR")

--- a/src/HydrodynamicTransport.jl
+++ b/src/HydrodynamicTransport.jl
@@ -22,6 +22,7 @@ include("BedExchangeModule.jl")
 # Added oyster
 include("OysterModule.jl")
 
+include("ReceptorMonitoringModule.jl")
 include("TimeSteppingModule.jl")
 
 
@@ -38,6 +39,7 @@ using .VerticalTransportModule
 using .SourceSinkModule
 using .HydrodynamicsModule
 using .OysterModule
+using .ReceptorMonitoringModule
 using .TimeSteppingModule
 using .UtilsModule
 # Note: The new modules are used internally by TimeSteppingModule,
@@ -50,6 +52,8 @@ export AbstractGrid, CartesianGrid, CurvilinearGrid, State, HydrodynamicData, Po
        BoundaryCondition, OpenBoundary, RiverBoundary, TidalBoundary, FunctionalInteraction,
        SedimentParams, DecayParams, OysterParams, OysterState, VirtualOyster # Export the new struct
        
+export ReceptorMonitor, create_receptor_monitor_from_lonlat, create_receptor_monitor_from_xy, flush_receptor_monitor!
+
 # Functions from GridModule.jl
 export initialize_cartesian_grid, initialize_curvilinear_grid
 

--- a/src/ReceptorMonitoringModule.jl
+++ b/src/ReceptorMonitoringModule.jl
@@ -1,0 +1,277 @@
+# src/ReceptorMonitoringModule.jl
+
+module ReceptorMonitoringModule
+
+export ReceptorMonitor, create_receptor_monitor_from_lonlat, create_receptor_monitor_from_xy, flush_receptor_monitor!, write_receptor_monitor!
+
+using ..HydrodynamicTransport.ModelStructs
+using ..HydrodynamicTransport.UtilsModule: lonlat_to_ij
+
+"""
+    ReceptorMonitor
+
+A generic mutable struct for monitoring tracer concentrations at specific receptor locations
+without writing the full domain state.
+
+# Fields
+- `receptor_id::String`: Identifier for the receptor.
+- `i::Int`, `j::Int`: Model/grid-facing receptor indices (for reporting).
+- `i_array::Int`, `j_array::Int`: Actual array indices used to index tracer arrays (accounting for halos).
+- `tracer_names::Vector{Symbol}`: Tracers to monitor.
+- `normalization_by_tracer::Dict{Symbol,Float64}`: User-supplied normalization constants for each tracer.
+- `output_file::String`: Path to the CSV output file.
+- `start_time_seconds::Float64`: Simulation start time, used to report elapsed time.
+- `extraction_mode::String`: Mode for extracting values (e.g., "volume_weighted_column_mean").
+- `clamp_negative_values::Bool`: If true, `kernel_value = clamped_value / normalization_value`. If false, `kernel_value = raw_value / normalization_value`.
+- `flush_every_n_monitor_times::Int`: Number of monitor times to buffer before flushing to disk.
+- `buffer::Vector{NamedTuple}`: Internal buffer for rows before writing.
+"""
+Base.@kwdef mutable struct ReceptorMonitor
+    receptor_id::String
+    i::Int
+    j::Int
+    i_array::Int
+    j_array::Int
+    tracer_names::Vector{Symbol}
+    normalization_by_tracer::Dict{Symbol,Float64}
+    output_file::String
+    start_time_seconds::Float64
+    extraction_mode::String = "volume_weighted_column_mean"
+    clamp_negative_values::Bool = true
+    flush_every_n_monitor_times::Int = 24
+    buffer::Vector{NamedTuple} = NamedTuple[]
+end
+
+"""
+    get_tracer_array(tracers, tracer::Symbol)
+
+Robustly fetches a tracer array from the tracers storage.
+"""
+function get_tracer_array(tracers, tracer::Symbol)
+    if tracers isa AbstractDict
+        haskey(tracers, tracer) && return tracers[tracer]
+        haskey(tracers, string(tracer)) && return tracers[string(tracer)]
+        return nothing
+    else
+        try
+            hasproperty(tracers, tracer) && return getproperty(tracers, tracer)
+        catch
+        end
+        return nothing
+    end
+end
+
+"""
+    receptor_vertical_weights(grid, i_array::Int, j_array::Int)
+
+Calculates the vertical weights for volume-weighted column mean extraction.
+For 3D grids with `volume`, returns normalized positive volumes.
+Otherwise, returns uniform weights `1.0 / nz`.
+"""
+function receptor_vertical_weights(grid, i_array::Int, j_array::Int)
+    nz = Int(grid.nz)
+
+    if hasproperty(grid, :volume)
+        # Assuming grid.volume has dimensions that can be indexed [i, j, k]
+        vols = [Float64(grid.volume[i_array, j_array, k]) for k in 1:nz]
+        posvols = [isfinite(v) && v > 0 ? v : 0.0 for v in vols]
+        total = sum(posvols)
+
+        if total > 0.0
+            return posvols ./ total
+        end
+    end
+
+    return fill(1.0 / nz, nz)
+end
+
+"""
+    receptor_monitor_rows(monitor::ReceptorMonitor, grid, state, time_seconds::Float64)
+
+Extracts tracer values for the receptor and returns a vector of rows (NamedTuples)
+to be appended to the monitor's buffer.
+"""
+function receptor_monitor_rows(monitor::ReceptorMonitor, grid, state, time_seconds::Float64)
+    rows = NamedTuple[]
+    elapsed_seconds = time_seconds - monitor.start_time_seconds
+    elapsed_hours = elapsed_seconds / 3600.0
+
+    weights = receptor_vertical_weights(grid, monitor.i_array, monitor.j_array)
+    nz = length(weights)
+
+    for tracer in monitor.tracer_names
+        A = get_tracer_array(state.tracers, tracer)
+        if A === nothing
+            @warn "Tracer '$tracer' not found in state.tracers for receptor '$(monitor.receptor_id)'. Skipping."
+            continue
+        end
+
+        # Extract the column
+        vals = [Float64(A[monitor.i_array, monitor.j_array, k]) for k in 1:nz]
+
+        raw_value = sum(vals .* weights)
+        clamped_value = sum(max.(vals, 0.0) .* weights)
+
+        normalization_value = get(monitor.normalization_by_tracer, tracer, NaN)
+
+        # Calculate kernel value as per user instructions
+        if isfinite(normalization_value) && normalization_value > 0
+            value_to_normalize = monitor.clamp_negative_values ? clamped_value : raw_value
+            kernel_value = value_to_normalize / normalization_value
+        else
+            kernel_value = NaN
+            @warn "Invalid receptor-monitor normalization value for tracer '$tracer' at receptor '$(monitor.receptor_id)': $normalization_value. Setting kernel_value to NaN."
+        end
+
+        local_min_raw = minimum(vals)
+        local_max_raw = maximum(vals)
+        local_negative_count = count(<(0.0), vals)
+        local_negative_fraction = local_negative_count / nz
+
+        row = (
+            time_seconds = time_seconds,
+            elapsed_seconds_since_start = elapsed_seconds,
+            elapsed_hours_since_start = elapsed_hours,
+            receptor_id = monitor.receptor_id,
+            grid_i = monitor.i,
+            grid_j = monitor.j,
+            array_i = monitor.i_array,
+            array_j = monitor.j_array,
+            tracer_id = string(tracer),
+            extraction_mode = monitor.extraction_mode,
+            raw_value = raw_value,
+            clamped_value = clamped_value,
+            normalization_value = normalization_value,
+            kernel_value = kernel_value,
+            local_min_raw = local_min_raw,
+            local_max_raw = local_max_raw,
+            local_negative_count = local_negative_count,
+            local_negative_fraction = local_negative_fraction
+        )
+        push!(rows, row)
+    end
+
+    return rows
+end
+
+"""
+    write_receptor_monitor!(monitor::ReceptorMonitor, grid, state, time_seconds::Float64)
+
+Buffers receptor monitor output for the current time and flushes if the threshold is reached.
+"""
+function write_receptor_monitor!(monitor::ReceptorMonitor, grid, state, time_seconds::Float64)
+    rows = receptor_monitor_rows(monitor, grid, state, time_seconds)
+    append!(monitor.buffer, rows)
+
+    rows_per_time = length(monitor.tracer_names)
+    threshold = monitor.flush_every_n_monitor_times * rows_per_time
+
+    if length(monitor.buffer) >= threshold
+        flush_receptor_monitor!(monitor)
+    end
+end
+
+"""
+    flush_receptor_monitor!(monitor::ReceptorMonitor)
+
+Flushes the buffered rows to the CSV file using a lightweight writer.
+"""
+function flush_receptor_monitor!(monitor::ReceptorMonitor)
+    isempty(monitor.buffer) && return
+
+    out_dir = dirname(monitor.output_file)
+    if !isempty(out_dir)
+        mkpath(out_dir)
+    end
+
+    is_new_file = !isfile(monitor.output_file)
+
+    # Lightweight CSV writing
+    open(monitor.output_file, "a") do io
+        if is_new_file
+            # Write header
+            header_keys = keys(first(monitor.buffer))
+            write(io, join(string.(header_keys), ","))
+            write(io, "\n")
+        end
+
+        for row in monitor.buffer
+            values = map(v -> v isa String ? "\"$v\"" : string(v), values(row))
+            write(io, join(values, ","))
+            write(io, "\n")
+        end
+    end
+
+    empty!(monitor.buffer)
+end
+
+"""
+    create_receptor_monitor_from_lonlat(...)
+
+Creates a ReceptorMonitor using geographic coordinates, leveraging `lonlat_to_ij`.
+"""
+function create_receptor_monitor_from_lonlat(
+    grid;
+    receptor_id::String,
+    lon::Float64,
+    lat::Float64,
+    tracer_names::Vector{Symbol},
+    normalization_by_tracer::Dict{Symbol,Float64},
+    output_file::String,
+    start_time_seconds::Float64,
+    extraction_mode::String = "volume_weighted_column_mean"
+)
+    result = lonlat_to_ij(grid, lon, lat)
+    result === nothing && error("Could not map receptor coordinates (lon: $lon, lat: $lat) to grid for receptor '$receptor_id'")
+
+    i = Int(result[1])
+    j = Int(result[2])
+
+    halo = hasproperty(grid, :ng) ? Int(grid.ng) : 0
+
+    return ReceptorMonitor(
+        receptor_id = receptor_id,
+        i = i,
+        j = j,
+        i_array = i + halo,
+        j_array = j + halo,
+        tracer_names = tracer_names,
+        normalization_by_tracer = normalization_by_tracer,
+        output_file = output_file,
+        start_time_seconds = start_time_seconds,
+        extraction_mode = extraction_mode
+    )
+end
+
+"""
+    create_receptor_monitor_from_xy(...)
+
+Creates a ReceptorMonitor using projected (X,Y) coordinates.
+Requires the grid to have an `xy_to_ij` method (or similar).
+If not implemented by the package, this function must be adapted.
+"""
+function create_receptor_monitor_from_xy(
+    grid;
+    receptor_id::String,
+    x::Float64,
+    y::Float64,
+    tracer_names::Vector{Symbol},
+    normalization_by_tracer::Dict{Symbol,Float64},
+    output_file::String,
+    start_time_seconds::Float64,
+    extraction_mode::String = "volume_weighted_column_mean"
+)
+    # If the package has an xy_to_ij, we'd use it here.
+    # We will assume a hypothetical `xy_to_ij` exists or error gracefully.
+    error("create_receptor_monitor_from_xy is currently unmapped; ensure xy_to_ij exists in UtilsModule to use this function.")
+
+    # Example placeholder:
+    # result = xy_to_ij(grid, x, y)
+    # result === nothing && error("Could not map receptor coordinates to grid")
+    # i = Int(result[1])
+    # j = Int(result[2])
+    # halo = hasproperty(grid, :ng) ? Int(grid.ng) : 0
+    # return ReceptorMonitor(...)
+end
+
+end # module ReceptorMonitoringModule

--- a/src/TimeSteppingModule.jl
+++ b/src/TimeSteppingModule.jl
@@ -13,6 +13,7 @@ using ..HydrodynamicTransport.BoundaryConditionsModule
 using ..HydrodynamicTransport.SettlingModule
 using ..HydrodynamicTransport.BedExchangeModule
 using ..HydrodynamicTransport.OysterModule
+using ..HydrodynamicTransport.ReceptorMonitoringModule: ReceptorMonitor, write_receptor_monitor!, flush_receptor_monitor!
 using ..HydrodynamicTransport.UtilsModule: calculate_max_cfl_term
 using ..HydrodynamicTransport.FluxLimitersModule 
 using ProgressMeter
@@ -50,6 +51,10 @@ function run_simulation(grid::AbstractGrid, initial_state::State, sources::Vecto
                         D_crit::Float64=0.0,
                         output_dir::Union{String, Nothing}=nothing,
                         output_interval::Union{Float64, Nothing}=nothing,
+                        write_full_state::Bool=true,
+                        full_state_output_interval::Union{Float64, Nothing}=output_interval,
+                        receptor_monitors::Vector{ReceptorMonitor}=ReceptorMonitor[],
+                        receptor_monitor_interval::Union{Float64, Nothing}=output_interval,
                         restart_from::Union{String, Nothing}=nothing)
 
     local state_to_run, effective_start_time
@@ -72,19 +77,38 @@ function run_simulation(grid::AbstractGrid, initial_state::State, sources::Vecto
     max_dt_taken = 0.0
     start_wall_time = time_ns()
 
-    next_output_time = if output_interval !== nothing
-        ceil((time + 1e-9) / output_interval) * output_interval
+    next_full_state_output_time = if full_state_output_interval !== nothing
+        ceil((time + 1e-9) / full_state_output_interval) * full_state_output_interval
     else
         Inf
     end
-    if output_dir !== nothing; mkpath(output_dir); end
+
+    next_receptor_monitor_time = if receptor_monitor_interval !== nothing
+        ceil((time + 1e-9) / receptor_monitor_interval) * receptor_monitor_interval
+    else
+        Inf
+    end
+
+    if output_dir !== nothing && write_full_state
+        mkpath(output_dir)
+    end
     
     desc_str = (ds !== nothing) ? "Simulating..." : "Simulating (test mode)..."
     pbar = Progress(floor(Int, end_time - time); desc=desc_str, dt=1.0)
 
     while time < end_time
         trial_dt = use_adaptive_dt ? min(current_dt, dt_max) : dt
-        trial_dt = min(trial_dt, end_time - time, next_output_time - time)
+
+        # Consider both output clocks for finding the next dt bound
+        dt_bound = end_time - time
+        if write_full_state && next_full_state_output_time < Inf
+            dt_bound = min(dt_bound, next_full_state_output_time - time)
+        end
+        if !isempty(receptor_monitors) && next_receptor_monitor_time < Inf
+            dt_bound = min(dt_bound, next_receptor_monitor_time - time)
+        end
+
+        trial_dt = min(trial_dt, dt_bound)
 
         if use_adaptive_dt && trial_dt < dt_min
             println("\nWarning: Timestep below minimum threshold. Stopping simulation.")
@@ -154,10 +178,17 @@ function run_simulation(grid::AbstractGrid, initial_state::State, sources::Vecto
         time += trial_dt
         state.time = time
         
-        if output_dir !== nothing && abs(time - next_output_time) < 1e-9
+        if !isempty(receptor_monitors) && time >= next_receptor_monitor_time - 1e-9
+            for monitor in receptor_monitors
+                write_receptor_monitor!(monitor, grid, state, time)
+            end
+            next_receptor_monitor_time += receptor_monitor_interval
+        end
+
+        if write_full_state && output_dir !== nothing && time >= next_full_state_output_time - 1e-9
             output_filename = joinpath(output_dir, "state_t_$(round(Int, time)).jld2")
             jldsave(output_filename; state=state, virtual_oysters=virtual_oysters)
-            next_output_time += output_interval
+            next_full_state_output_time += full_state_output_interval
         end
 
         elapsed_wall_time_min = (time_ns() - start_wall_time) / 1e9 / 60
@@ -170,6 +201,12 @@ function run_simulation(grid::AbstractGrid, initial_state::State, sources::Vecto
         ])
     end
     ProgressMeter.finish!(pbar)
+
+    # Flush all monitors at the end of the simulation
+    for monitor in receptor_monitors
+        flush_receptor_monitor!(monitor)
+    end
+
     return state
 end
 
@@ -197,21 +234,35 @@ function run_and_store_simulation(grid::AbstractGrid, initial_state::State, sour
                                   limiter_func::Function=FluxLimitersModule.van_leer, # <-- NEW ARGUMENT
                                   Kh::Float64=1.0,
                                   Kz::Float64=1e-4,
-                                  D_crit::Float64=0.0)
+                                  D_crit::Float64=0.0,
+                                  write_full_state::Bool=true,
+                                  full_state_output_interval::Union{Float64, Nothing}=output_interval,
+                                  receptor_monitors::Vector{ReceptorMonitor}=ReceptorMonitor[],
+                                  receptor_monitor_interval::Union{Float64, Nothing}=output_interval)
                                   
     state = deepcopy(initial_state)
     time = start_time
     current_dt = dt
     results = [(state=deepcopy(state), oysters=deepcopy(virtual_oysters))]
     timesteps = [start_time]
-    next_output_time = start_time + output_interval
+    next_full_state_output_time = start_time + (full_state_output_interval !== nothing ? full_state_output_interval : output_interval)
+    next_receptor_monitor_time = start_time + (receptor_monitor_interval !== nothing ? receptor_monitor_interval : output_interval)
 
     desc_str = (ds !== nothing) ? "Simulating & Storing (Real Data)..." : "Simulating & Storing (Test Mode)..."
     pbar = Progress(floor(Int, end_time - time); desc=desc_str, dt=1.0)
     
     while time < end_time
         trial_dt = use_adaptive_dt ? min(current_dt, dt_max) : dt
-        trial_dt = min(trial_dt, end_time - time, next_output_time - time)
+
+        dt_bound = end_time - time
+        if write_full_state
+            dt_bound = min(dt_bound, next_full_state_output_time - time)
+        end
+        if !isempty(receptor_monitors)
+            dt_bound = min(dt_bound, next_receptor_monitor_time - time)
+        end
+
+        trial_dt = min(trial_dt, dt_bound)
 
         if use_adaptive_dt && trial_dt < dt_min
             @warn "\nWarning: Timestep below minimum threshold. Stopping simulation."
@@ -277,14 +328,26 @@ function run_and_store_simulation(grid::AbstractGrid, initial_state::State, sour
         time += trial_dt
         state.time = time
         
-        if abs(time - next_output_time) < 1e-9
+        if !isempty(receptor_monitors) && time >= next_receptor_monitor_time - 1e-9
+            for monitor in receptor_monitors
+                write_receptor_monitor!(monitor, grid, state, time)
+            end
+            next_receptor_monitor_time += receptor_monitor_interval !== nothing ? receptor_monitor_interval : output_interval
+        end
+
+        if write_full_state && time >= next_full_state_output_time - 1e-9
             push!(results, (state=deepcopy(state), oysters=deepcopy(virtual_oysters)))
             push!(timesteps, time)
-            next_output_time += output_interval
+            next_full_state_output_time += full_state_output_interval !== nothing ? full_state_output_interval : output_interval
         end
         ProgressMeter.update!(pbar, floor(Int, time - start_time))
     end
     ProgressMeter.finish!(pbar)
+
+    for monitor in receptor_monitors
+        flush_receptor_monitor!(monitor)
+    end
+
     return results, timesteps
 end
 

--- a/validation_migration_note.md
+++ b/validation_migration_note.md
@@ -1,0 +1,66 @@
+# Validation and Migration Note: Generic Receptor Monitoring
+
+## 1. Migration / Usage Updates
+
+### Old Usage
+Previously, `run_simulation` and `run_and_store_simulation` only supported saving the full-grid 3D state using the `output_interval` parameter.
+```julia
+HydrodynamicTransport.run_simulation(
+    grid, state, sources, start_time, end_time, dt;
+    output_dir = "output",
+    output_interval = 21600.0,  # Wrote full state every 6 hours
+    # ... other args
+)
+```
+Existing scripts structured this way will continue to work perfectly and the behavior remains identical: full states will be written every `output_interval`.
+
+### New Usage
+The simulation now supports **high-frequency, lightweight receptor monitoring** decoupled from full-state outputs. You can specify different output frequencies for full state vs receptor outputs, or entirely disable full state writing.
+
+```julia
+monitor_a = HydrodynamicTransport.create_receptor_monitor_from_lonlat(
+    grid;
+    receptor_id = "RECEPTOR_A",
+    lon = -1.5, lat = 47.0,
+    tracer_names = [:TRACER_1],
+    normalization_by_tracer = Dict(:TRACER_1 => 1.0e12),
+    output_file = "output/RECEPTOR_A_monitor.csv",
+    start_time_seconds = start_time
+)
+
+HydrodynamicTransport.run_simulation(
+    grid, state, sources, start_time, end_time, dt;
+    output_dir = "output",
+    # Old parameter acts as a fallback default, but you can be explicit:
+    write_full_state = false,
+    full_state_output_interval = 24.0 * 3600.0,
+
+    receptor_monitors = [monitor_a],
+    receptor_monitor_interval = 1.0 * 3600.0,  # CSV rows every 1 hr
+)
+```
+
+## 2. Validation Requirements
+
+You must run the following three tests manually in your environment to validate correctness.
+
+### Test A: Backward Compatibility Test
+**Objective**: Ensure existing simulations run exactly as before.
+1. Run a script using only the `output_interval` and `output_dir` arguments.
+2. Provide no monitor arguments (`receptor_monitors = ReceptorMonitor[]`).
+3. **Pass Condition**: The full domain state files (`state_t_*.jld2`) are correctly saved at the specified `output_interval`.
+
+### Test B: Receptor Monitor Smoke Test
+**Objective**: Ensure the CSV monitors output the expected rows without writing full states.
+1. Run a short test (e.g. 2 hours of simulated time) with `receptor_monitor_interval = 1.0 * 3600.0`.
+2. Configure 2 receptors and 2 tracers.
+3. Set `write_full_state = false`.
+4. **Pass Condition**: No `state_t_*.jld2` files are generated. Two distinct CSV files are produced, each containing 4 rows (assuming the model writes at `start_time + interval` and end time) or exactly the mathematically predicted amount based on time boundaries. The CSV must contain `time_seconds`, `receptor_id`, `tracer_id`, `raw_value`, `clamped_value`, and `kernel_value`.
+
+### Test C: Comparison Against Full-State Post-Processing
+**Objective**: Guarantee that receptor monitor extraction matches full-state data physically.
+1. Run a short simulation with `write_full_state = true` and both `full_state_output_interval` and `receptor_monitor_interval` set to exactly the same value (e.g. 1 hour).
+2. Wait for the simulation to finish.
+3. Use external post-processing tools to load the `state_t_*.jld2` files.
+4. Calculate the column mean (if 3D) or cell value at the exact array index reported by the receptor CSV.
+5. **Pass Condition**: The independently computed volume-weighted value must agree with the `raw_value` recorded in the receptor monitor CSV to machine numerical precision.


### PR DESCRIPTION
This PR introduces a generic receptor-monitoring system that allows users to record high-frequency time series data at specific receptor locations without having to write out expensive full-grid model state files.

### Key Features:
1. **ReceptorMonitoringModule:** A new module implementing the `ReceptorMonitor` struct and related helper functions (tracer extraction, vertical volume-weighting, writing and buffering).
2. **Decoupled Output:** Re-engineered the output scheduling in `run_simulation` and `run_and_store_simulation` to use separate clocks. This allows full-state output to be configured entirely separately from receptor monitoring (or disabled entirely with `write_full_state=false`).
3. **No Heavy Dependencies:** The CSV writing mechanism relies entirely on standard library IO rather than adding `CSV.jl` and `DataFrames.jl` to the project manifest.
4. **Backward Compatibility:** All new kwargs strictly preserve the previous API behavior when invoked by legacy scripts.
5. **Generics & Best Practices:** Hard-coded variables or paths have been strictly avoided, maintaining the library's general usability.

Includes an example runner in the `examples/` directory and validation notes for manual testing.

---
*PR created automatically by Jules for task [15600613571406617914](https://jules.google.com/task/15600613571406617914) started by @microstijn*